### PR TITLE
Clean up docker-related stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config-test.ini
 test_local
 sdk.cfg
 deploy.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ RUN wget https://github.com/kbase/dockerize/raw/master/dockerize-linux-amd64-$DO
     tar -C /usr/local/bin -xvzf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-# Clean up any apt installations
-RUN apt-get remove -y wget && \
-    apt-get autoremove -y && apt-get autoclean -y
-
 COPY . /app
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
-FROM python:3
+FROM python:3.7-slim
 
 MAINTAINER KBase Developer
 
-ADD requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt
+# Install pip requirements
+ARG DEVELOPMENT
+COPY requirements.txt dev-requirements.txt /tmp/
 
-RUN wget https://github.com/kbase/dockerize/raw/master/dockerize-linux-amd64-v0.6.1.tar.gz && \
-    tar xvzf dockerize-linux-amd64-v0.6.1.tar.gz && \
-    mv dockerize /usr/bin && \
-    rm *.tar.gz
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
+    if [ "$DEVELOPMENT" ]; then pip install --no-cache-dir -r /tmp/dev-requirements.txt; fi && \
+    rm /tmp/*requirements.txt
 
-ADD . /app
+RUN apt-get update && \
+    apt-get install -y wget
+
+# Install dockerize
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/kbase/dockerize/raw/master/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xvzf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# Clean up any apt installations
+RUN apt-get remove -y wget && \
+    apt-get autoremove -y && apt-get autoclean -y
+
+COPY . /app
 
 WORKDIR /app
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+nose==1.3.7
+mypy==0.630
+bandit==1.5.1
+flake8==3.5.0
+coverage==4.5.3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,10 @@ services:
           memory: 550M
 
   indexrunner:
-    image: kbase/indexrunner
+    build:
+      context: .
+      args:
+        DEVELOPMENT: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}/test_local/scratch:/app/work
@@ -59,7 +62,10 @@ services:
       PYTHONUNBUFFERED: 1
 
   admin:
-    image: kbase/indexrunner
+    build:
+      context: .
+      args:
+        DEVELOPMENT: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}/test_local/work:/app/work

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-confluent-kafka
-coverage
-docker
+confluent-kafka==0.11.6
+docker==3.7.0
 elasticsearch==5.5.3
-nose
-PyYAML
-requests
+PyYAML==3.13
+requests==2.21.0


### PR DESCRIPTION
- Add a separate dev-requirements.txt file for test and linting requirements that don't need to be installed in prod
- Reduce the docker image size
- Pin all pip dependency versions
- gitignore config-test.ini so we don't accidentally commit a CI admin token